### PR TITLE
Fix build script for Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/index.js",
+    "build": "npx vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/index.js",
     "start": "node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"


### PR DESCRIPTION
## Summary
- explicitly run Vite and esbuild via `npx` in the build script

## Testing
- `npm install`
- `npm run check` *(fails: Property 'sport' does not exist and ServerOptions mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68420baebc70832bb6650bcdfb2b6a56