### PR TITLE
Add vite as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
         "tsx": "^4.19.1",
         "tw-animate-css": "^1.2.5",
         "vaul": "^1.1.2",
-        "vite": "^5.4.14",
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
         "zod": "^3.24.2",
@@ -98,7 +97,8 @@
         "drizzle-kit": "^0.30.4",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.17",
-        "typescript": "5.6.3"
+        "typescript": "5.6.3",
+        "vite": "^5.4.14"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.8"
@@ -5705,7 +5705,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5725,7 +5724,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5745,7 +5743,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -5765,7 +5762,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5785,7 +5781,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5805,7 +5800,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5825,7 +5819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5845,7 +5838,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5865,7 +5857,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5885,7 +5876,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
     "zustand": "^5.0.4",
     "@vitejs/plugin-react": "^4.3.2",
     "esbuild": "^0.25.0",
-    "tsx": "^4.19.1",
-    "vite": "^5.4.14"
+    "tsx": "^4.19.1"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.1.2",
@@ -100,7 +99,8 @@
     "drizzle-kit": "^0.30.4",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "vite": "^5.4.14"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- move `vite` to `devDependencies` so Render can install build tools

## Testing
- `npm install --package-lock-only`

------
https://chatgpt.com/codex/tasks/task_e_684a19031ddc832ba905de82e613fb37