### PR TITLE
Add drizzle migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+.DS_Store
+
+# Drizzle migration artifact meta
+migrations/meta

--- a/migrations/0000_sturdy_red_ghost.sql
+++ b/migrations/0000_sturdy_red_ghost.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "games" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" varchar(100) NOT NULL,
+	"skill_level" varchar(50) NOT NULL,
+	"location" varchar(100) NOT NULL,
+	"game_types" text NOT NULL,
+	"date" varchar(50),
+	"tee_time" varchar(50),
+	"number_of_players" integer DEFAULT 1,
+	"details" text,
+	"created_at" timestamp DEFAULT now(),
+	"organizer_id" integer
+);
+--> statement-breakpoint
+CREATE TABLE "players" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"skill_level" varchar(50) NOT NULL,
+	"handicap" varchar(10),
+	"preferred_course" varchar(100),
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"password" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_organizer_id_users_id_fk" FOREIGN KEY ("organizer_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "npx vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/index.js",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push",
+    "db:push": "npx drizzle-kit push:postgres",
+    "migrate": "npm run db:push",
     "prebuild": "npm ci"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- generate first migration for `users`, `games`, and `players` tables
- configure `.gitignore`
- add `migrate` npm script using `drizzle-kit push:postgres`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684a3b332cb0832ba55f0910288bf6dd