### PR TITLE
Add migration script with Drizzle ORM

### DIFF
--- a/migrate.ts
+++ b/migrate.ts
@@ -1,0 +1,8 @@
+import { execSync } from 'node:child_process';
+
+try {
+  execSync('npx drizzle-kit push', { stdio: 'inherit' });
+} catch (err) {
+  console.error('Migration failed:', err);
+  process.exit(1);
+}

--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "games" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" varchar(100) NOT NULL,
+	"skill_level" varchar(50) NOT NULL,
+	"location" varchar(100) NOT NULL,
+	"game_types" text NOT NULL,
+	"date" varchar(50),
+	"tee_time" varchar(50),
+	"number_of_players" integer DEFAULT 1,
+	"details" text,
+	"created_at" timestamp DEFAULT now(),
+	"organizer_id" integer
+);
+--> statement-breakpoint
+CREATE TABLE "players" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"skill_level" varchar(50) NOT NULL,
+	"handicap" varchar(10),
+	"preferred_course" varchar(100),
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"password" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_organizer_id_users_id_fk" FOREIGN KEY ("organizer_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/migrations/0000_sad_wendell_vaughn.sql
+++ b/migrations/0000_sad_wendell_vaughn.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "games" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" varchar(100) NOT NULL,
+	"skill_level" varchar(50) NOT NULL,
+	"location" varchar(100) NOT NULL,
+	"game_types" text NOT NULL,
+	"date" varchar(50),
+	"tee_time" varchar(50),
+	"number_of_players" integer DEFAULT 1,
+	"details" text,
+	"created_at" timestamp DEFAULT now(),
+	"organizer_id" integer
+);
+--> statement-breakpoint
+CREATE TABLE "players" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"skill_level" varchar(50) NOT NULL,
+	"handicap" varchar(10),
+	"preferred_course" varchar(100),
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"password" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_organizer_id_users_id_fk" FOREIGN KEY ("organizer_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "npx drizzle-kit push:postgres",
-    "migrate": "npm run db:push",
+    "migrate": "tsx migrate.ts",
     "prebuild": "npm ci"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- generate initial migration
- add migrate.ts script to run `drizzle-kit push`
- wire migrate.ts in package.json
- include generated migration SQL for reference

## Testing
- `npm run migrate` *(fails: ECONNREFUSED since no Postgres DB is running)*

------
https://chatgpt.com/codex/tasks/task_e_684a42275920832bab886bfee2933592